### PR TITLE
UPP-1521 - Added new field: storyPackageUuid + formatting

### DIFF
--- a/src/main/java/com/ft/content/model/Content.java
+++ b/src/main/java/com/ft/content/model/Content.java
@@ -34,6 +34,7 @@ public class Content {
     private final String externalBinaryUrl;
     private final SortedSet<Member> members;
     private final String mainImage;
+    private final String storyPackageUuid;
     private final Standout standout;
     private final Comments comments;
     private final Copyright copyright;
@@ -60,6 +61,7 @@ public class Content {
                    @JsonProperty("externalBinaryUrl") String externalBinaryUrl,
                    @JsonProperty("members") SortedSet<Member> members,
                    @JsonProperty("mainImage") String mainImage,
+                   @JsonProperty("storyPackageUuid") String storyPackageUuid,
                    @JsonProperty("standout") Standout standout,
                    @JsonProperty("comments") Comments comments,
                    @JsonProperty("copyright") Copyright copyright,
@@ -87,6 +89,7 @@ public class Content {
         this.externalBinaryUrl = externalBinaryUrl;
         this.members = members;
         this.mainImage = mainImage;
+        this.storyPackageUuid = storyPackageUuid;
         this.copyright = copyright;
         this.webUrl = webUrl;
         this.publishReference = publishReference;
@@ -168,6 +171,10 @@ public class Content {
         return mainImage;
     }
 
+    public String getStoryPackageUuid() {
+        return storyPackageUuid;
+    }
+
     public Comments getComments() {
         return comments;
     }
@@ -222,6 +229,7 @@ public class Content {
                 .add("externalBinaryUrl", externalBinaryUrl)
                 .add("members", members)
                 .add("mainImage", mainImage)
+                .add("storyPackageUuid", storyPackageUuid)
                 .add("comments", comments)
                 .add("standout", standout)
                 .add("webUrl", webUrl)
@@ -256,6 +264,7 @@ public class Content {
                 && Objects.equals(this.externalBinaryUrl, that.externalBinaryUrl)
                 && Objects.equals(this.members, that.members)
                 && Objects.equals(this.mainImage, that.mainImage)
+                && Objects.equals(this.storyPackageUuid, that.storyPackageUuid)
                 && Objects.equals(this.comments, that.comments)
                 && Objects.equals(this.standout, that.standout)
                 && Objects.equals(this.copyright, that.copyright)
@@ -268,7 +277,30 @@ public class Content {
 
     @Override
     public int hashCode() {
-        return Objects.hash(title, alternativeTitles, byline, brands, identifiers, uuid, publishedDate, standfirst, body, description, mediaType, pixelWidth, pixelHeight, internalBinaryUrl, externalBinaryUrl, members, mainImage, comments, standout, publishReference, lastModified, canBeSyndicated, firstPublishedDate);
+        return Objects.hash(title,
+                alternativeTitles,
+                byline,
+                brands,
+                identifiers,
+                uuid,
+                publishedDate,
+                standfirst,
+                body,
+                description,
+                mediaType,
+                pixelWidth,
+                pixelHeight,
+                internalBinaryUrl,
+                externalBinaryUrl,
+                members,
+                mainImage,
+                storyPackageUuid,
+                comments,
+                standout,
+                publishReference,
+                lastModified,
+                canBeSyndicated,
+                firstPublishedDate);
     }
 
     public static Builder builder() {
@@ -294,6 +326,7 @@ public class Content {
         private String externalBinaryUrl;
         private SortedSet<Member> members;
         private String mainImage;
+        private String storyPackageUuid;
         private Comments comments;
         private Standout standout;
         private Copyright copyright;
@@ -388,6 +421,11 @@ public class Content {
             return this;
         }
 
+        public Builder withStoryPackageUuid(String storyPackageUuid) {
+            this.storyPackageUuid = storyPackageUuid;
+            return this;
+        }
+
         public Builder withComments(Comments comments) {
             this.comments = comments;
             return this;
@@ -446,6 +484,7 @@ public class Content {
                     .withExternalBinaryUrl(content.getExternalBinaryUrl())
                     .withMembers(content.getMembers())
                     .withMainImage(content.getMainImage())
+                    .withStoryPackageUuid(content.getStoryPackageUuid())
                     .withComments(content.getComments())
                     .withStandout(content.getStandout())
                     .withCopyright(content.getCopyright())
@@ -467,7 +506,7 @@ public class Content {
                     standfirst, body, description,
                     mediaType,
                     pixelWidth, pixelHeight, internalBinaryUrl, externalBinaryUrl,
-                    members, mainImage,
+                    members, mainImage, storyPackageUuid,
                     standout, comments, copyright, webUrl, transactionId, lastModified, canBeSyndicated, firstPublishedDate);
         }
     }

--- a/src/main/java/com/ft/content/model/Content.java
+++ b/src/main/java/com/ft/content/model/Content.java
@@ -34,7 +34,7 @@ public class Content {
     private final String externalBinaryUrl;
     private final SortedSet<Member> members;
     private final String mainImage;
-    private final String storyPackageUuid;
+    private final String storyPackage;
     private final Standout standout;
     private final Comments comments;
     private final Copyright copyright;
@@ -61,7 +61,7 @@ public class Content {
                    @JsonProperty("externalBinaryUrl") String externalBinaryUrl,
                    @JsonProperty("members") SortedSet<Member> members,
                    @JsonProperty("mainImage") String mainImage,
-                   @JsonProperty("storyPackageUuid") String storyPackageUuid,
+                   @JsonProperty("storyPackage") String storyPackage,
                    @JsonProperty("standout") Standout standout,
                    @JsonProperty("comments") Comments comments,
                    @JsonProperty("copyright") Copyright copyright,
@@ -89,7 +89,7 @@ public class Content {
         this.externalBinaryUrl = externalBinaryUrl;
         this.members = members;
         this.mainImage = mainImage;
-        this.storyPackageUuid = storyPackageUuid;
+        this.storyPackage = storyPackage;
         this.copyright = copyright;
         this.webUrl = webUrl;
         this.publishReference = publishReference;
@@ -171,8 +171,8 @@ public class Content {
         return mainImage;
     }
 
-    public String getStoryPackageUuid() {
-        return storyPackageUuid;
+    public String getStoryPackage() {
+        return storyPackage;
     }
 
     public Comments getComments() {
@@ -229,7 +229,7 @@ public class Content {
                 .add("externalBinaryUrl", externalBinaryUrl)
                 .add("members", members)
                 .add("mainImage", mainImage)
-                .add("storyPackageUuid", storyPackageUuid)
+                .add("storyPackage", storyPackage)
                 .add("comments", comments)
                 .add("standout", standout)
                 .add("webUrl", webUrl)
@@ -264,7 +264,7 @@ public class Content {
                 && Objects.equals(this.externalBinaryUrl, that.externalBinaryUrl)
                 && Objects.equals(this.members, that.members)
                 && Objects.equals(this.mainImage, that.mainImage)
-                && Objects.equals(this.storyPackageUuid, that.storyPackageUuid)
+                && Objects.equals(this.storyPackage, that.storyPackage)
                 && Objects.equals(this.comments, that.comments)
                 && Objects.equals(this.standout, that.standout)
                 && Objects.equals(this.copyright, that.copyright)
@@ -294,7 +294,7 @@ public class Content {
                 externalBinaryUrl,
                 members,
                 mainImage,
-                storyPackageUuid,
+                storyPackage,
                 comments,
                 standout,
                 publishReference,
@@ -326,7 +326,7 @@ public class Content {
         private String externalBinaryUrl;
         private SortedSet<Member> members;
         private String mainImage;
-        private String storyPackageUuid;
+        private String storyPackage;
         private Comments comments;
         private Standout standout;
         private Copyright copyright;
@@ -421,8 +421,8 @@ public class Content {
             return this;
         }
 
-        public Builder withStoryPackageUuid(String storyPackageUuid) {
-            this.storyPackageUuid = storyPackageUuid;
+        public Builder withStoryPackage(String storyPackage) {
+            this.storyPackage = storyPackage;
             return this;
         }
 
@@ -484,7 +484,7 @@ public class Content {
                     .withExternalBinaryUrl(content.getExternalBinaryUrl())
                     .withMembers(content.getMembers())
                     .withMainImage(content.getMainImage())
-                    .withStoryPackageUuid(content.getStoryPackageUuid())
+                    .withStoryPackage(content.getStoryPackage())
                     .withComments(content.getComments())
                     .withStandout(content.getStandout())
                     .withCopyright(content.getCopyright())
@@ -506,7 +506,7 @@ public class Content {
                     standfirst, body, description,
                     mediaType,
                     pixelWidth, pixelHeight, internalBinaryUrl, externalBinaryUrl,
-                    members, mainImage, storyPackageUuid,
+                    members, mainImage, storyPackage,
                     standout, comments, copyright, webUrl, transactionId, lastModified, canBeSyndicated, firstPublishedDate);
         }
     }

--- a/src/test/java/com/ft/content/model/ContentTest.java
+++ b/src/test/java/com/ft/content/model/ContentTest.java
@@ -36,6 +36,7 @@ public class ContentTest {
                 .withXmlBody("The body")
                 .withMembers(ImmutableSortedSet.of(new Member("member1"), new Member("member2")))
                 .withMainImage(UUID.randomUUID().toString())
+                .withStoryPackageUuid(UUID.randomUUID().toString())
                 .withComments(new Comments(true))
                 .withStandout(new Standout(true, true, true))
                 .withWebUrl(URI.create("http://www.ft.com/a-url"))
@@ -193,6 +194,16 @@ public class ContentTest {
         final Content otherContent = Content.builder()
                 .withValuesFrom(content)
                 .withMainImage(UUID.randomUUID().toString())
+                .build();
+
+        assertThat(content, is(not(equalTo(otherContent))));
+    }
+
+    @Test
+    public void contentWithDifferentStoryPackageUuidsAreNotEqual() {
+        final Content otherContent = Content.builder()
+                .withValuesFrom(content)
+                .withStoryPackageUuid(UUID.randomUUID().toString())
                 .build();
 
         assertThat(content, is(not(equalTo(otherContent))));

--- a/src/test/java/com/ft/content/model/ContentTest.java
+++ b/src/test/java/com/ft/content/model/ContentTest.java
@@ -36,7 +36,7 @@ public class ContentTest {
                 .withXmlBody("The body")
                 .withMembers(ImmutableSortedSet.of(new Member("member1"), new Member("member2")))
                 .withMainImage(UUID.randomUUID().toString())
-                .withStoryPackageUuid(UUID.randomUUID().toString())
+                .withStoryPackage(UUID.randomUUID().toString())
                 .withComments(new Comments(true))
                 .withStandout(new Standout(true, true, true))
                 .withWebUrl(URI.create("http://www.ft.com/a-url"))
@@ -200,10 +200,10 @@ public class ContentTest {
     }
 
     @Test
-    public void contentWithDifferentStoryPackageUuidsAreNotEqual() {
+    public void contentWithDifferentStoryPackagesAreNotEqual() {
         final Content otherContent = Content.builder()
                 .withValuesFrom(content)
-                .withStoryPackageUuid(UUID.randomUUID().toString())
+                .withStoryPackage(UUID.randomUUID().toString())
                 .build();
 
         assertThat(content, is(not(equalTo(otherContent))));


### PR DESCRIPTION
__Note__: This field is needed to construct the Neo4j relation between the lead article and the story package. 

We intend to filter out this field before storing the article model to MongoDB (in document-store-api). 
I was wondering if there might be similar use cases in the future and to have some general map field, e.g. "internals" instead of this storyPackageUuid which will be filtered out before storing to Mongo. Any thoughts on that?