### PR TITLE
Syndication/Distribution to recognize case sensitive values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.Financial-Times</groupId>
     <artifactId>content-model</artifactId>
-    <version>0.2.00</version>
+    <version>0.2.01</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/ft/content/model/Distribution.java
+++ b/src/main/java/com/ft/content/model/Distribution.java
@@ -28,8 +28,8 @@ public enum Distribution {
     public String getDistributionStatus() {
         return distributionStatus;
     }
-    
-	public static Distribution fromString(String value) {
-		return distributionMap.get(value.toLowerCase());
-	}
+
+    public static Distribution fromString(String value) {
+	return distributionMap.get(value.toLowerCase());
+    }
 }

--- a/src/main/java/com/ft/content/model/Distribution.java
+++ b/src/main/java/com/ft/content/model/Distribution.java
@@ -1,13 +1,24 @@
 package com.ft.content.model;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.Maps;
 
 public enum Distribution {
     YES("yes"),
     NO("no"),
     VERIFY("verify");
 
-    private String distributionStatus;
+	private static Map<String, Distribution> distributionMap = Maps.newHashMap();
+    
+	private String distributionStatus;
+
+	static {
+		for (Distribution d : values()) {
+			distributionMap.put(d.getDistributionStatus(), d);
+		}
+	}
 
     Distribution(String distributionStatus) {
         this.distributionStatus = distributionStatus;
@@ -17,4 +28,8 @@ public enum Distribution {
     public String getDistributionStatus() {
         return distributionStatus;
     }
+    
+	public static Distribution fromString(String value) {
+		return distributionMap.get(value.toLowerCase());
+	}
 }

--- a/src/main/java/com/ft/content/model/Syndication.java
+++ b/src/main/java/com/ft/content/model/Syndication.java
@@ -1,13 +1,24 @@
 package com.ft.content.model;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.Maps;
 
 public enum Syndication {
     YES("yes"),
     NO("no"),
     VERIFY("verify");
 
-    private String canBeSyndicated;
+	private static Map<String, Syndication> syndicationMap = Maps.newHashMap();
+
+	private String canBeSyndicated;
+    
+	static {
+		for (Syndication s : values()) {
+			syndicationMap.put(s.getCanBeSyndicated(), s);
+		}
+	}
 
     Syndication(String canBeSyndicated) {
         this.canBeSyndicated = canBeSyndicated;
@@ -17,4 +28,8 @@ public enum Syndication {
     public String getCanBeSyndicated() {
         return canBeSyndicated;
     }
+    
+	public static Syndication fromString(String value) {
+		return syndicationMap.get(value.toLowerCase());
+	}
 }

--- a/src/main/java/com/ft/content/model/Syndication.java
+++ b/src/main/java/com/ft/content/model/Syndication.java
@@ -29,7 +29,7 @@ public enum Syndication {
         return canBeSyndicated;
     }
     
-	public static Syndication fromString(String value) {
-		return syndicationMap.get(value.toLowerCase());
-	}
+    public static Syndication fromString(String value) {
+	return syndicationMap.get(value.toLowerCase());
+    }
 }


### PR DESCRIPTION
`Syndication.valueOf("No")` will return null, so we need a new method that ignores case-sensitive values for both `canBeSyndicated` and `canBeDistributed` fields. 